### PR TITLE
Fix buffer overrun in ChangeWindowText

### DIFF
--- a/Source/Client/Main/Window.cpp
+++ b/Source/Client/Main/Window.cpp
@@ -445,15 +445,16 @@ void CWindow::ChangeWindowText()
 		return;
 	}
 
-	char text[256];
+	std::array<char, 256> text = { 0 };
 
 	STRUCT_DECRYPT;
 
-	sprintf_s(text, sizeof(text), "%s || Resets: %d || GrandResets: %d || Level: %d || PING: %u ms || FPS: %.0f", (char*)(CharacterAttribute + 0x00), gPrintPlayer.ViewReset, gPrintPlayer.ViewGrandReset, *(WORD*)(CharacterAttribute + 0x0E), gPrintPlayer.ViewPing, FPS);
+	sprintf_s(text.data(), sizeof(text), "%s || Resets: %d || GrandResets: %d || Level: %d || PING: %u ms || FPS: %.0f",
+							(char*)(CharacterAttribute + 0x00), gPrintPlayer.ViewReset, gPrintPlayer.ViewGrandReset, *(WORD*)(CharacterAttribute + 0x0E), gPrintPlayer.ViewPing, FPS);
 
 	STRUCT_ENCRYPT;
 
-	SetWindowText(g_hWnd, text);
+	SetWindowText(g_hWnd, text.data());
 }
 
 void CWindow::SetWindowMode(bool windowMode, bool borderless)

--- a/Source/Client/Main/stdafx.h
+++ b/Source/Client/Main/stdafx.h
@@ -23,6 +23,7 @@
 #include <mbstring.h>
 #include <fstream>
 #include <deque>
+#include <array>
 
 // General Includes
 #include "Console.h"


### PR DESCRIPTION
Fixes buffer overrun when running the game in Release mode.

In the future It would be nice to replace all C style arrays with C++ array class, it's much safer and has no overhead.

Thank you for the sources you've provided, I may not have any experience with Mu Online, but starting with your files will help me to learn the game. :heart: 


Closes: https://github.com/nicomuratona/MuEmu-0.97k-kayito/issues/22