### PR TITLE
Properly clear allocated memory in GetAsBinary method.

### DIFF
--- a/Source/MuServer/DataServer/QueryManager.cpp
+++ b/Source/MuServer/DataServer/QueryManager.cpp
@@ -734,7 +734,7 @@ void CQueryManager::GetAsBinary(std::string ColName, unsigned char* OutBuffer, i
 
 	memcpy(OutBuffer, result, OutBufferSize);
 
-	delete result;
+	delete[] result;
 }
 
 void CQueryManager::ConvertStringToBinary(char* InBuff, int InSize, unsigned char* OutBuff, int OutSize)

--- a/Source/MuServer/JoinServer/QueryManager.cpp
+++ b/Source/MuServer/JoinServer/QueryManager.cpp
@@ -734,7 +734,7 @@ void CQueryManager::GetAsBinary(std::string ColName, unsigned char* OutBuffer, i
 
 	memcpy(OutBuffer, result, OutBufferSize);
 
-	delete result;
+	delete[] result;
 }
 
 void CQueryManager::ConvertStringToBinary(char* InBuff, int InSize, unsigned char* OutBuff, int OutSize)


### PR DESCRIPTION
Since result is an array it's best to clear using the delete[] operator.